### PR TITLE
fix bug in browsers that use webkit-mask-image instead of mask-image

### DIFF
--- a/subshelves/dist/naie-subshelves.user.js
+++ b/subshelves/dist/naie-subshelves.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Novel AI Enhanced: Sub-shelves
 // @namespace    github.nystik-hg
-// @version      1.0.4
+// @version      1.0.5
 // @description  Adds nested shelves functionality
 // @match        https://novelai.net/*
 // @grant        none
@@ -934,9 +934,12 @@ const findTitleBar = () => {
 }
 
 const findElementWithMaskImage = (elements, urlSubstrings) => {
-    let results = [...elements].filter((e) => {
-        const maskImageValue = e ? window.getComputedStyle(e).getPropertyValue('mask-image') : null
-        return maskImageValue && urlSubstrings.every((sub) => maskImageValue.includes(sub))
+    const results = [...elements].filter((e) => {
+        const computedStyle = e ? window.getComputedStyle(e) : null
+        const maskImageValue = computedStyle ? computedStyle.getPropertyValue('mask-image') : null
+        const finalMaskImageValue = maskImageValue || (computedStyle ? computedStyle.getPropertyValue('-webkit-mask-image') : null)
+
+        return finalMaskImageValue && urlSubstrings.every((sub) => finalMaskImageValue.includes(sub))
     })
     return results
 }

--- a/subshelves/modules/dom/general.dom.js
+++ b/subshelves/modules/dom/general.dom.js
@@ -106,9 +106,12 @@ const findTitleBar = () => {
 }
 
 const findElementWithMaskImage = (elements, urlSubstrings) => {
-    let results = [...elements].filter((e) => {
-        const maskImageValue = e ? window.getComputedStyle(e).getPropertyValue('mask-image') : null
-        return maskImageValue && urlSubstrings.every((sub) => maskImageValue.includes(sub))
+    const results = [...elements].filter((e) => {
+        const computedStyle = e ? window.getComputedStyle(e) : null
+        const maskImageValue = computedStyle ? computedStyle.getPropertyValue('mask-image') : null
+        const finalMaskImageValue = maskImageValue || (computedStyle ? computedStyle.getPropertyValue('-webkit-mask-image') : null)
+
+        return finalMaskImageValue && urlSubstrings.every((sub) => finalMaskImageValue.includes(sub))
     })
     return results
 }

--- a/subshelves/naie-subshelves.user.js
+++ b/subshelves/naie-subshelves.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Novel AI Enhanced: Sub-shelves
 // @namespace    github.nystik-hg
-// @version      1.0.4
+// @version      1.0.5
 // @description  Adds nested shelves functionality
 // @match        https://novelai.net/*
 // @grant        none


### PR DESCRIPTION
Closes #3 

Some browsers use webkit- prefix for the mask-image css property. This fix implements support for that.